### PR TITLE
Added editor notes field and control when editing.

### DIFF
--- a/src/lib/components/content/Medium.svelte
+++ b/src/lib/components/content/Medium.svelte
@@ -87,6 +87,14 @@
       Back to List
     </a>
 
+    {#if $admin > 1}
+      {#await import('svelte-pieces/data/JSON.svelte') then { default: JSON }}
+        <div class="ml-auto">
+          <JSON obj={data} />
+        </div>
+      {/await}
+    {/if}
+
     <button
       class="hover:bg-primary-500 text-primary-700 hover:text-white btn rounded
       px-4 py-2 font-bold hover:shadow text-sm focus:outline-none
@@ -120,20 +128,15 @@
 
   <slot translator={$translator} />
 
-  {#if $translator}
-    <div class="p-2 flex flex-wrap">
-      <slot name="translator" />
+  {#if $admin || (data && $user && data.createdBy === $user.uid)}
+    <div class="p-2">
+      <slot name="admin" />
     </div>
   {/if}
 
-  {#if $admin || (data && $user && data.createdBy === $user.uid)}
+  {#if $translator}
     <div class="p-2 flex flex-wrap">
-      <slot name="admin" />
-      {#if $admin > 1}
-        {#await import('$lib/components/utilities/JSON.svelte') then { default: JSON }}
-          <JSON obj={data} />
-        {/await}
-      {/if}
+      <slot name="translator" />
     </div>
   {/if}
 </div>

--- a/src/lib/components/ui/Datepicker.svelte
+++ b/src/lib/components/ui/Datepicker.svelte
@@ -26,7 +26,7 @@
 
   import { createEventDispatcher } from 'svelte';
   const dispatch = createEventDispatcher();
-  import Button from './Button.svelte';
+  import Button from 'svelte-pieces/ui/Button.svelte';
 
   async function setManualSubscriptionEndDate(user: IUser, endDate: Date) {
     await updateOnline(`users/${user.uid}`, {

--- a/src/lib/interfaces/media.interface.ts
+++ b/src/lib/interfaces/media.interface.ts
@@ -14,6 +14,7 @@ export interface IMedia extends IFirestoreMetaData {
 
   // TODO: this is set in media.ts, is it still needed?
   currentVerses?: number[];
+  editorNotes?: string;
 }
 
 export type TranslationFields = {

--- a/src/routes/[version]/[bookId]/[reference]/doc/[documentId].svelte
+++ b/src/routes/[version]/[bookId]/[reference]/doc/[documentId].svelte
@@ -94,6 +94,29 @@
     {/await}
   {/if}
 
+  <div slot="admin">
+    {#if document.editorNotes}
+      <div class="mb-4 p-2 bg-gray-200 rounded">
+        <div class="text-xs font-semibold">Editor Notes</div>
+        <ParsedParagraph value={document.editorNotes} />
+      </div>
+    {/if}
+
+    <div class="flex">
+      <a
+        sveltekit:prefetch
+        class="font-medium px-3 py-2 hover:bg-gray-200 text-primary-700 rounded
+      border border-primary-700"
+        href="/{$page.params.version}/{$page.params.bookId}/{$page.params
+          .reference}/doc/{document.id}/edit"
+      >
+        Edit
+        <i class="fas fa-key" />
+      </a>
+      &nbsp;
+    </div>
+  </div>
+
   <div class="flex" slot="translator">
     <a
       sveltekit:prefetch
@@ -103,20 +126,6 @@
         .reference}/doc/{document.id}/translate"
     >
       Translate to {LanguageMappings[translatorLanguage]}
-      <i class="fas fa-key" />
-    </a>
-    &nbsp;
-  </div>
-
-  <div class="flex" slot="admin">
-    <a
-      sveltekit:prefetch
-      class="font-medium px-3 py-2 hover:bg-gray-200 text-primary-700 rounded
-      border border-primary-700"
-      href="/{$page.params.version}/{$page.params.bookId}/{$page.params
-        .reference}/doc/{document.id}/edit"
-    >
-      Edit
       <i class="fas fa-key" />
     </a>
     &nbsp;

--- a/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
+++ b/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
@@ -360,6 +360,9 @@
     >
       Add Paragraph
     </Button>
+    <div class="mt-5 prose max-w-none">
+      <ClassicCustomized bind:html={document.editorNotes} />
+    </div>
     {#if $admin > 1}
       <input
         type="text"

--- a/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
+++ b/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
@@ -19,13 +19,7 @@
   import EditVerseIds from '$lib/components/content/EditVerseIds.svelte';
   import ImageInDoc from '../_ImageInDoc.svelte';
   import ClassicCustomized from '$lib/components/editor/ClassicCustomized.svelte';
-  import {
-    addOnline,
-    collectionStore,
-    deleteDocumentOnline,
-    Doc,
-    updateOnline,
-  } from '$sveltefirets';
+  import { addOnline, collectionStore, deleteDocumentOnline, Doc, update } from '$sveltefirets';
   import { orderBy } from 'firebase/firestore';
 
   export let documentId: string;
@@ -42,7 +36,7 @@
 
   async function save(document: IDocument) {
     try {
-      await updateOnline(`media/${document.id}`, document);
+      await update(`media/${document.id}`, document);
 
       if (document.authors) {
         for (const authorInDoc of document.authors) {
@@ -377,8 +371,8 @@
   </form>
 
   {#if $admin > 1}
-    {#await import('$lib/components/utilities/JSON.svelte') then JSON}
-      <JSON.default obj={document} />
+    {#await import('svelte-pieces/data/JSON.svelte') then { default: JSON }}
+      <JSON obj={document} />
     {/await}
   {/if}
 {/if}

--- a/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
+++ b/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/edit.svelte
@@ -354,9 +354,14 @@
     >
       Add Paragraph
     </Button>
-    <div class="mt-5 prose max-w-none">
-      <ClassicCustomized bind:html={document.editorNotes} />
+
+    <div class="my-4 p-2 bg-gray-200 rounded">
+      <div class="text-xs font-semibold mb-2">Editor Notes (will not be published)</div>
+      <div class="prose max-w-none">
+        <ClassicCustomized bind:html={document.editorNotes} />
+      </div>
     </div>
+
     {#if $admin > 1}
       <input
         type="text"

--- a/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/translate.svelte
+++ b/src/routes/[version]/[bookId]/[reference]/doc/[documentId]/translate.svelte
@@ -57,7 +57,7 @@
   />
 
   {#if $admin > 1}
-    {#await import('$lib/components/utilities/JSON.svelte') then { default: JSON }}
+    {#await import('svelte-pieces/data/JSON.svelte') then { default: JSON }}
       <JSON obj={document} />
     {/await}
   {/if}

--- a/src/routes/[version]/[bookId]/[reference]/img/[imageId]/edit.svelte
+++ b/src/routes/[version]/[bookId]/[reference]/img/[imageId]/edit.svelte
@@ -380,8 +380,8 @@
   </form>
 
   {#if $admin > 1}
-    {#await import('$lib/components/utilities/JSON.svelte') then JSON}
-      <JSON.default obj={image} />
+    {#await import('svelte-pieces/data/JSON.svelte') then { default: JSON }}
+      <JSON obj={image} />
     {/await}
   {/if}
 {/if}

--- a/src/routes/account.svelte
+++ b/src/routes/account.svelte
@@ -167,7 +167,7 @@
   {/if}
 
   {#if $admin > 1}
-    {#await import('$lib/components/utilities/JSON.svelte') then { default: JSON }}
+    {#await import('svelte-pieces/data/JSON.svelte') then { default: JSON }}
       <JSON obj={$user} />
     {/await}
   {/if}


### PR DESCRIPTION
#### Relevant Issue
#2 

#### Summarize what changed in this PR (for developers)
Editors can now add unpublished notes to articles and images.

#### Summarize changes in this PR (for public-facing changelog)
NA

#### How can the changes be tested? Please provide applicable links using relative paths or (even better) use the preview deployment url (will require editing this message once the preview deployment is ready).
Edit https://hvsb-git-add-editor-notes-field-hvsb.vercel.app/WEB/MAT/1/doc/4ksmpgO0pBPYQ4M09Et1 and add some editor notes.

<a href="https://gitpod.io/#https://github.com/HVSBible/hvsb/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

