### PR TITLE
Moved author and image credits to admin search section

### DIFF
--- a/src/lib/components/search/SearchWrapper.svelte
+++ b/src/lib/components/search/SearchWrapper.svelte
@@ -110,14 +110,14 @@
         {/if}
 
         <RefinementList {search} attribute="genre" label="Genres" />
-        <RefinementList {search} attribute="author" label="Authors" />
-        <RefinementList {search} attribute="credit" label="Image Credit" />
         <RefinementList {search} attribute="location" label="Locations" />
         <RefinementList {search} attribute="subject" label="Subjects" />
 
         {#if $admin}
           <hr class="mb-2" />
           <h4 class="text-xs font-semibold uppercase text-gray-700">Admin</h4>
+          <RefinementList {search} attribute="author" label="Authors" />
+          <RefinementList {search} attribute="credit" label="Image Credit" />
           <RefinementList {search} attribute="bookIds" label="Books" />
           <RefinementList {search} attribute="chapterIds" label="Chapters" />
           <RefinementList {search} attribute="createdBy" label="Created by" />


### PR DESCRIPTION
#### Relevant Issue
Only show author and image credits for an admin user.
#### Summarize what changed in this PR (for developers)
Moved the author and image credits filters to the admin section in the search wrapper component.
#### Summarize changes in this PR (for public-facing changelog)
Users will not see author and image credits filters on the search page.
#### How can the changes be tested? Please provide applicable links using relative paths or (even better) use the preview deployment url (will require editing this message once the preview deployment is ready).


<a href="https://gitpod.io/#https://github.com/HVSBible/hvsb/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

